### PR TITLE
Adding additional option to manage several schemas

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,8 @@ flyway.password = PASSWORD
 See [Flyway - Config Files](https://flywaydb.org/documentation/configfiles) for option details.
 
 * `flyway.outOfOrder`
+* `flyway.schemas`
+* `flyway.cleanOnValidationError`
 
 ## AWS Settings
 

--- a/src/main/scala/crossroad0201/aws/flywaylambda/deploy/FlywayDeployment.scala
+++ b/src/main/scala/crossroad0201/aws/flywaylambda/deploy/FlywayDeployment.scala
@@ -39,6 +39,7 @@ object FlywayOption {
     conf.asScala.flatMap {
       case ("flyway.outOfOrder", enabled) => Some(OutOfOrder(enabled.toBoolean))
       case ("flyway.cleanOnValidationError", enabled) => Some(CleanOnValidationError(enabled.toBoolean))
+      case ("flyway.schemas", schemas) => Some(Schemas(schemas.split(",").map(_.trim)))
       case _ => None
     }.toSeq
   }
@@ -53,6 +54,13 @@ case class OutOfOrder(enabled: Boolean) extends FlywayOption {
 case class CleanOnValidationError(enabled: Boolean) extends FlywayOption {
   override def apply(flyway: Flyway) = {
     flyway.setCleanOnValidationError(enabled)
+    flyway
+  }
+}
+
+case class Schemas(schemas: Array[String]) extends FlywayOption {
+  override def apply(flyway: Flyway) = {
+    flyway.setSchemas(schemas)
     flyway
   }
 }


### PR DESCRIPTION
Hi @crossroad0201 ! 
Sorry to bother you again, I need another PR for this, this time I'm adding another option to select the schemas that flyway should manage. I'm not very proficient in Scala, so I'm not completely sure if I am split the schemas string correctly or if the class for schema has the proper type on it's constructor, I do know that the setSchemas should accept a String array. Let me know if I'm doing something wrong and I hope this can be merged soon. Thanks!